### PR TITLE
chore: add netlify deploy badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# Portfolio (Next.js)
+
+[![Netlify Status](https://api.netlify.com/api/v1/badges/818895a1-d3ff-4b78-af36-ee00ffc84708/deploy-status)](https://app.netlify.com/sites/darwinpsmith/deploys)
+
+This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](<https://github.com/vercel/next.js/tree/canary/>
+packages/create-next-app).
 
 ## Getting Started
 


### PR DESCRIPTION
- Adds Netlify Deployment Status Badge: 
> [![Netlify Status](https://api.netlify.com/api/v1/badges/818895a1-d3ff-4b78-af36-ee00ffc84708/deploy-status)](https://app.netlify.com/sites/darwinpsmith/deploys)